### PR TITLE
uniqueArray corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@
     var unique = [];
 
     for(var i = 0; i < array.length; i++) {
-      // If key returns null (unique), it is evaluated as false.
+      // If key returns undefined (unique), it is evaluated as false.
       if(!hashmap.hasOwnProperty([array[i]])) {
         hashmap[array[i]] = 1;
         unique.push(array[i]);

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@
 
     for(var i = 0; i < array.length; i++) {
       // If key returns undefined (unique), it is evaluated as false.
-      if(!hashmap.hasOwnProperty([array[i]])) {
+      if(!hashmap.hasOwnProperty(array[i])) {
         hashmap[array[i]] = 1;
         unique.push(array[i]);
       }


### PR DESCRIPTION
If object (`hasmap`) doesn't have key specified `undefined` is returned, not `null`.

Check if object `hasOwnProperty` of the number, not array of number:
`array[i]` instead of `[array[i]]`